### PR TITLE
Receive build notifications via Atomist

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -1,0 +1,17 @@
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.0-20170816122823"
+editor:
+  name: "AddTravisWebhookEditor"
+  group: "atomist"
+  artifact: "enrollment-rugs"
+  version: "0.4.0"
+  origin:
+    repo: "git@github.com:atomisthq/enrollment-rugs.git"
+    branch: "master"
+    sha: "9a33e81"
+  parameters:
+    - "atomistWebhookUrl": "https://webhook.atomist.com/atomist/travis/teams/T0474LR00"
+    - "teamId": "T0474LR00"
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.atomist.yml linguist-generated=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,11 @@ script:
 notifications:
   slack:
     secure: jJ3ZVC1hxVShU5PI9CtUuDB6sTxjjE0AnNAUMJmE2QqNMWztUOYrdHkcahYv8xi4ebPs78tb8d9zMSWQqyCCqcHdZFnfTd/TLpKu184C+Jh1fyu9asLe6rnHLwsDPFzQKz9cfGQK60JEWOrHJD4eJMB35U6W1UT+oTaWod4AR/tmbzkDg5jfcwfH9+DLor6iI2KmAcAHAUP/v6nL2pJBp5codwjwDXSmTV95xP60lguL6MQefz6Wh+0k+KtDZ1RX7omugd4rbCAGwji2m9oL+JbFW9ABERfLL6ohUiE7UJQpGo//vnbF+hox0xuTL73ZEPFVQ7/T3K6tyCrbVy9HxHjCKWivJXHGQY7wNPfIS7xRKG1FBv5kFyawXr//Yg/LvaGCQc0oYrUdwGh177yl/TH7g0nbZwPH0oFud2f340RB1DMTFIkxWGOuhC6LALln6yqbh0+STjN89xUIqUB7JBbl2QANUX1vFvNj8/FeDfTV4G+wMz40FJfb5ds+nKTOq1r03wuq8C1o5BdwxVc9L2KOsrKsQ7GQwmS8k2LQTKXIUNTpoOzvFG2kdFruM0pYafm9mCQYtUQogsy7ahPDbv0zlTq0P4EX5xbup8JjO3rQrBy80WTpLwZnEx+sgaSk9+tsDzfSXGc3b9x7DndktopUCEe0yK/aEn+cCY8T6TM=
+  webhooks:
+    urls:
+    - 'https://webhook.atomist.com/atomist/travis/teams/T0474LR00'
+    on_cancel: always
+    on_error: always
+    on_start: always
+    on_failure: always
+    on_success: always


### PR DESCRIPTION
Send build events to Atomist.

They'll be incorporated into GitHub push and PR notifications,
so you'll see dynamically updated build results along with your commits.
Look for them in this channel in Slack.

[Travis webhook documentation](https://docs.travis-ci.com/user/notifications/#Configuring-webhook-notifications)